### PR TITLE
test for /electron/ in the path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath);
+module.exports = process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) p || /[\\/]electron[\\/]/.test(process.execPath);


### PR DESCRIPTION
This PR adds a supplementary check for an `electron` directory in the app's execution path. 

From http://electron.atom.io/docs/api/process/#processdefaultapp

> When app is started by being passed as parameter to the default app, this property is `true` in the main process, otherwise it is `undefined`.

For most development cases, the `process.defaultApp` check will be true, but for situations where that's undefined (renderer processes?), the path fallbacks will be used.

This doesn't depend on https://github.com/electron-userland/electron-prebuilt/pull/118

Fixes #2
