### PR TITLE
Make `ELECTRON_IS_DEV` override default behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 'use strict';
+const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
+const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
 
-const getFromEnv = () => {
-	if ('ELECTRON_IS_DEV' in process.env) {
-		return parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
-	}
-
-	return false;
-};
-
-module.exports = getFromEnv() || process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /[\\/]electron[\\/]/.test(process.execPath);
+module.exports = isEnvSet ? getFromEnv : process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /[\\/]electron[\\/]/.test(process.execPath);

--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@
 const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
 const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
 
-module.exports = isEnvSet ? getFromEnv : process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /[\\/]electron[\\/]/.test(process.execPath);
+module.exports = isEnvSet ? getFromEnv : (process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /[\\/]electron[\\/]/.test(process.execPath));


### PR DESCRIPTION
See https://github.com/sindresorhus/electron-is-dev/commit/251a445362af30006b9a0d3475e778ec36ed839a#commitcomment-22917036. Setting `ELECTRON_IS_DEV=0` could lead to `isDev`being `true` anyway if any of the other tests pass.