### PR TITLE
Only match `electron` path inside `node_modules`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,4 @@
 const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
 const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
 
-module.exports = isEnvSet ? getFromEnv : (process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /[\\/]electron[\\/]/.test(process.execPath));
+module.exports = isEnvSet ? getFromEnv : (process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath) || /node_modules[\\/]electron[\\/]/.test(process.execPath));


### PR DESCRIPTION
Fixes #4.