### PR TITLE
Fix for Create React App applications

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
-const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
-const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
+const proc = typeof window !== 'undefined' && typeof window.process !== 'undefined' ? window.process : process;
+const getFromEnv = parseInt(proc.env.ELECTRON_IS_DEV, 10) === 1;
+const isEnvSet = 'ELECTRON_IS_DEV' in proc.env;
 
-module.exports = isEnvSet ? getFromEnv : (process.defaultApp || /node_modules[\\/]electron[\\/]/.test(process.execPath));
+module.exports = isEnvSet ? getFromEnv : (proc.defaultApp || /node_modules[\\/]electron[\\/]/.test(proc.execPath));


### PR DESCRIPTION
In the renderer process of Create React App applications, `process` does not provide the full object, only `window.process` does. Prefers `window.process` when it is available.