### PR TITLE
Detect when not run in an Electron environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 const electron = require('electron');
 
-if (typeof electron === "string") throw new Error("Not running in an Electron environment!")
+if (typeof electron === 'string') {
+	throw new TypeError('Not running in an Electron environment!');
+}
 
 const app = electron.app || electron.remote.app;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 const electron = require('electron');
 
+if (typeof electron === "string") throw new Error("Not running in an Electron environment!")
+
 const app = electron.app || electron.remote.app;
 
 const isEnvSet = 'ELECTRON_IS_DEV' in process.env;


### PR DESCRIPTION
Catches when `electron-is-dev` is using in a regular Node.js application.