### PR TITLE
Drop support for working directly in the renderer process

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@ if (typeof electron === 'string') {
 	throw new TypeError('Not running in an Electron environment!');
 }
 
-const app = electron.app || electron.remote.app;
-
 const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
 const getFromEnv = parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
 
-module.exports = isEnvSet ? getFromEnv : !app.isPackaged;
+module.exports = isEnvSet ? getFromEnv : !electron.app.isPackaged;

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Useful for enabling debug features only during development.
 
-You can use this module in the Electron main process.
+This package must be used from the Electron main process.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Useful for enabling debug features only during development.
 
-You can use this module directly in both the main and renderer process.
+You can use this module in the Electron main process.
 
 
 ## Install


### PR DESCRIPTION
Removes the `remote` module so the package can only be used in the main process.

This probably warrants bumping the package version to `2.x` since some people may be using it in the renderer process.

We don't use this package in our project so I haven't tested it as I'd like, but the changes are minor and the automated tests pass so I think it should be alright.

@sindresorhus