### PR TITLE
Handle running in a remote situation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const remote = require('@electron/remote');
 
 if (typeof electron === 'string') {
 	throw new TypeError('Not running in an Electron environment!');
@@ -8,4 +9,4 @@ if (typeof electron === 'string') {
 const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
 const getFromEnv = Number.parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
 
-module.exports = isEnvSet ? getFromEnv : !electron.app.isPackaged;
+module.exports = isEnvSet ? getFromEnv : !(electron.app || remote.app).isPackaged;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
 		"xo": "^0.38.1"
 	},
 	"dependencies": {
-		"@electron/remote": "^2.0.0"
+		"@electron/remote": "^2.0.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "electron-is-dev",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Check if Electron is running in development",
 	"license": "MIT",
 	"repository": "sindresorhus/electron-is-dev",
@@ -32,5 +32,8 @@
 	"devDependencies": {
 		"tsd": "^0.14.0",
 		"xo": "^0.38.1"
+	},
+	"dependencies": {
+		"@electron/remote": "^2.0.0"
 	}
 }


### PR DESCRIPTION
This tries getting a handle on `app` via `@electron/remote` if `electron.app` is not present. This enables the usage of this lib in preload files.